### PR TITLE
Disable some annoying yellow box warning 😩

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,12 @@
-import { AppRegistry } from "react-native";
+import { AppRegistry, YellowBox } from "react-native";
 import App from "./src/App";
+
+YellowBox.ignoreWarnings([
+    "Warning: isMounted(...) is deprecated",
+    ...[
+        "RCTImageLoader",
+        // Add module names here 👇, here 👆 or here 👈... 🤗
+    ].map(module => `Module ${module} requires main queue setup`),
+])
 
 AppRegistry.registerComponent("stdrenegade", () => App);


### PR DESCRIPTION
- **isMounted(...) is deprecated**: 
This warnings is due to the deprecation of `isMounted` and introduction of `UNSAFE_componentWillMount`, `UNSAFE_componentWillReceiveProps`, `UNSAFE_componentWillUpdate` in React 16.3 (see [Update on Async Rendering](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html)). They are visible from ReatNative 0.54 which updated the version of Reactjs it uses.
- **Module XXXXX requires main queue setup**:
As the complete warning message say: _In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of._

**NB.** Warnings are still visible in console.