### PR TITLE
Header component

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,5 +1,17 @@
 import React from "react"
-import { SafeAreaView, ImageBackground, Animated, Dimensions, StyleSheet } from "react-native"
+import {
+    SafeAreaView,
+    ImageBackground,
+    Animated,
+    Dimensions,
+    StyleSheet,
+    ViewPropTypes,
+    TouchableOpacity,
+    Text,
+} from "react-native"
+import PropTypes from "prop-types"
+
+const windowSize = Dimensions.get("window")
 
 const Header = (props) => (
     <ImageBackground
@@ -7,26 +19,31 @@ const Header = (props) => (
         style={[props.styles, styles.container]}
         resizeMode="cover"
     >
-        <SafeAreaView>
+        <SafeAreaView style={{ flex: 1 }}>
             <Animated.Image
                 source={require("../res/images/logo.png")}
-                style={{ height: props.height || Header.maxHeight }}
+                style={{ height: props.height }}
                 resizeMode="contain"
             />
         </SafeAreaView>
     </ImageBackground>
 )
-
-const windowSize = Dimensions.get("window")
-
 Header.minHeight = 0
 Header.maxHeight = 80
-Header.animatedHeight = ({ deltaY }) =>
-    deltaY.interpolate({
+Header.animatedHeight = ({ scrollContentYOffset }) =>
+    scrollContentYOffset.interpolate({
         inputRange: [-windowSize.height, 0, Header.maxHeight - Header.minHeight],
         outputRange: [Header.maxHeight + windowSize.height * 0.3, Header.maxHeight, Header.minHeight],
         useNativeDriver: true,
     })
+
+Header.propTypes = {
+    style: ViewPropTypes.style,
+    height: PropTypes.object,
+}
+Header.defaultProps = {
+    height: Header.maxHeight,
+}
 
 const styles = StyleSheet.create({
     container: {

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,48 +1,75 @@
 import React from "react"
-import {
-    SafeAreaView,
-    ImageBackground,
-    Animated,
-    Dimensions,
-    StyleSheet,
-    ViewPropTypes,
-    TouchableOpacity,
-    Text,
-} from "react-native"
+import { SafeAreaView, ImageBackground, Animated, Easing, Dimensions, StyleSheet, ViewPropTypes } from "react-native"
 import PropTypes from "prop-types"
 
 const windowSize = Dimensions.get("window")
 
-const Header = (props) => (
-    <ImageBackground
-        source={require("../res/images/header-back.jpg")}
-        style={[props.styles, styles.container]}
-        resizeMode="cover"
-    >
-        <SafeAreaView style={{ flex: 1 }}>
-            <Animated.Image
-                source={require("../res/images/logo.png")}
-                style={{ height: props.height }}
-                resizeMode="contain"
-            />
-        </SafeAreaView>
-    </ImageBackground>
-)
-Header.minHeight = 0
-Header.maxHeight = 80
-Header.animatedHeight = ({ scrollContentYOffset }) =>
-    scrollContentYOffset.interpolate({
-        inputRange: [-windowSize.height, 0, Header.maxHeight - Header.minHeight],
-        outputRange: [Header.maxHeight + windowSize.height * 0.3, Header.maxHeight, Header.minHeight],
-        useNativeDriver: true,
-    })
+class Header extends React.Component {
+    static propTypes = {
+        style: ViewPropTypes.style,
+        scrollContentYOffset: PropTypes.number,
+    }
+    static defaultProps = {
+        scrollContentYOffset: 0,
+    }
+    // Header animation configuration
+    static minHeight = 0
+    static maxHeight = 80
+    static deltaAnimationProgressThatDoesNotNeedTiming = 0.5
+    static computeAnimatedProgressValue = ({ scrollContentYOffset }) =>
+        scrollContentYOffset >= 0
+            ? Math.max(0, 1 - scrollContentYOffset / (Header.maxHeight - Header.minHeight))
+            : 1 + (-scrollContentYOffset * 0.3) / (Header.maxHeight - Header.minHeight) // Bounce
+    static animatedHeight = ({ animatedProgress }) =>
+        Animated.multiply(animatedProgress, Header.maxHeight - Header.minHeight)
+    static animatedOpacity = ({ animatedProgress }) => animatedProgress
 
-Header.propTypes = {
-    style: ViewPropTypes.style,
-    height: PropTypes.object,
-}
-Header.defaultProps = {
-    height: Header.maxHeight,
+    constructor(props) {
+        super(props)
+        this.animatedProgressValue = Header.computeAnimatedProgressValue({
+            scrollContentYOffset: this.props.scrollContentYOffset,
+        })
+        this.animatedProgress = new Animated.Value(this.animatedProgressValue)
+    }
+
+    componentDidUpdate() {
+        const { scrollContentYOffset } = this.props
+        const newAnimatedProgressValue = Header.computeAnimatedProgressValue({ scrollContentYOffset })
+        if (
+            Math.abs(this.animatedProgressValue - newAnimatedProgressValue) <=
+            Header.deltaAnimationProgressThatDoesNotNeedTiming
+        ) {
+            this.animatedProgress.setValue(newAnimatedProgressValue)
+        } else {
+            Animated.timing(this.animatedProgress, {
+                toValue: newAnimatedProgressValue,
+                duration: 200,
+                easing: Easing.out(Easing.quad),
+            }).start()
+        }
+        this.animatedProgressValue = newAnimatedProgressValue
+    }
+
+    render() {
+        return (
+            <ImageBackground
+                source={require("../res/images/header-back.jpg")}
+                style={[this.props.styles, styles.container]}
+                resizeMode="cover"
+            >
+                <SafeAreaView style={{ flex: 1 }}>
+                    <Animated.Image
+                        source={require("../res/images/logo.png")}
+                        style={{
+                            height: Header.animatedHeight({ animatedProgress: this.animatedProgress }),
+                            opacity: Header.animatedOpacity({ animatedProgress: this.animatedProgress }),
+                        }}
+                        resizeMode="contain"
+                    />
+                </SafeAreaView>
+            </ImageBackground>
+        )
+    }
 }
 
 const styles = StyleSheet.create({

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,23 +1,42 @@
-import React from 'react';
-import {View, Image, StyleSheet, Text} from 'react-native';
+import React from "react"
+import { SafeAreaView, ImageBackground, Animated, Dimensions, StyleSheet } from "react-native"
 
-const Header = () => {
-    return (
-      <View>
-        <Image source={require('../res/images/header-back.jpg')} style={{height:125, width:'100%'}} />
-        <Image source={require('../res/images/logo.png')} style={styles.positionLogo} />
-      </View>
-    )
-  }
+const Header = (props) => (
+    <ImageBackground
+        source={require("../res/images/header-back.jpg")}
+        style={[props.styles, styles.container]}
+        resizeMode="cover"
+    >
+        <SafeAreaView>
+            <Animated.Image
+                source={require("../res/images/logo.png")}
+                style={{ height: props.height || Header.maxHeight }}
+                resizeMode="contain"
+            />
+        </SafeAreaView>
+    </ImageBackground>
+)
+
+const windowSize = Dimensions.get("window")
+
+Header.minHeight = 0
+Header.maxHeight = 80
+Header.animatedHeight = ({ deltaY }) =>
+    deltaY.interpolate({
+        inputRange: [-windowSize.height, 0, Header.maxHeight - Header.minHeight],
+        outputRange: [Header.maxHeight + windowSize.height * 0.3, Header.maxHeight, Header.minHeight],
+        useNativeDriver: true,
+    })
 
 const styles = StyleSheet.create({
-  positionLogo: {
-    width: 80,
-    height: 80,
-    position: "absolute",
-    top: "25%",
-    left: "40%"
-  }
-});
+    container: {
+        position: "absolute",
+        top: 0,
+        left: 0,
+        right: 0,
+        alignItems: "center",
+        justifyContent: "center",
+    },
+})
 
 export default Header

--- a/src/components/ScrollViewWithHeader.js
+++ b/src/components/ScrollViewWithHeader.js
@@ -1,0 +1,46 @@
+import React, { Component } from "react"
+import { SafeAreaView, StyleSheet, ViewPropTypes, ScrollView, Animated } from "react-native"
+import PropTypes from "prop-types"
+
+import Header from "./Header"
+
+export default class ScrollViewWithHeader extends Component {
+    static propTypes = {
+        style: ViewPropTypes.style,
+        children: PropTypes.node,
+        navigation: PropTypes.object, // Provide navigation object if header is in navigation stack
+    }
+
+    constructor(props) {
+        super(props)
+        this.state = {
+            offsetY: new Animated.Value(0),
+        }
+        this._headerHeight = Header.animatedHeight({ scrollContentYOffset: this.state.offsetY })
+        props.navigation && props.navigation.setParams({ headerHeight: this._headerHeight })
+    }
+
+    _onScroll = ({ nativeEvent }) => this.state.offsetY.setValue(nativeEvent.contentOffset.y)
+
+    render() {
+        return (
+            <SafeAreaView style={this.props.style}>
+                <ScrollView style={{ flex: 1 }} scrollEventThrottle={16} onScroll={this._onScroll}>
+                    <Animated.View style={{ flex: 1, paddingTop: this._headerHeight }}>
+                        {this.props.children}
+                    </Animated.View>
+                </ScrollView>
+                {!this.props.navigation && <Header style={styles.header} height={this._headerHeight} />}
+            </SafeAreaView>
+        )
+    }
+}
+
+const styles = StyleSheet.create({
+    header: {
+        position: "absolute",
+        top: 0,
+        left: 0,
+        right: 0,
+    },
+})

--- a/src/components/ScrollViewWithHeader.js
+++ b/src/components/ScrollViewWithHeader.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react"
-import { SafeAreaView, StyleSheet, ViewPropTypes, ScrollView, Animated } from "react-native"
+import { SafeAreaView, StyleSheet, ViewPropTypes, ScrollView, View } from "react-native"
 import PropTypes from "prop-types"
 
 import Header from "./Header"
@@ -11,26 +11,22 @@ export default class ScrollViewWithHeader extends Component {
         navigation: PropTypes.object, // Provide navigation object if header is in navigation stack
     }
 
-    constructor(props) {
-        super(props)
-        this.state = {
-            offsetY: new Animated.Value(0),
-        }
-        this._headerHeight = Header.animatedHeight({ scrollContentYOffset: this.state.offsetY })
-        props.navigation && props.navigation.setParams({ headerHeight: this._headerHeight })
+    state = {
+        offsetY: 0,
     }
 
-    _onScroll = ({ nativeEvent }) => this.state.offsetY.setValue(nativeEvent.contentOffset.y)
+    onScroll = ({ nativeEvent }) =>
+        this.props.navigation
+            ? this.props.navigation.setParams({ scrollContentYOffset: nativeEvent.contentOffset.y })
+            : this.setState({ offsetY: nativeEvent.contentOffset.y })
 
     render() {
         return (
             <SafeAreaView style={this.props.style}>
-                <ScrollView style={{ flex: 1 }} scrollEventThrottle={16} onScroll={this._onScroll}>
-                    <Animated.View style={{ flex: 1, paddingTop: this._headerHeight }}>
-                        {this.props.children}
-                    </Animated.View>
+                <ScrollView style={{ flex: 1 }} scrollEventThrottle={16} onScroll={this.onScroll}>
+                    <View style={{ flex: 1, marginTop: Header.maxHeight }}>{this.props.children}</View>
                 </ScrollView>
-                {!this.props.navigation && <Header style={styles.header} height={this._headerHeight} />}
+                {!this.props.navigation && <Header style={styles.header} scrollContentYOffset={this.state.offsetY} />}
             </SafeAreaView>
         )
     }

--- a/src/screens/home/Home.js
+++ b/src/screens/home/Home.js
@@ -1,77 +1,59 @@
-import React, { Component } from "react";
-import {
-  StyleSheet,
-  Text,
-  View,
-  Image,
-  Linking,
-  TouchableHighlight
-} from "react-native";
-// React-Native-Elements
+import React, { Component } from "react"
+import { StyleSheet, Text, View, Image, Linking, TouchableHighlight } from "react-native"
 
-// React-Navigation
-import { TabNavigator } from "react-navigation";
-// Component
-import Header from "../../components/Header";
-import Agenda from "../../components/Agenda";
+import Agenda from "../../components/Agenda"
+import ScrollViewWithHeader from "../../components/ScrollViewWithHeader"
 
 export default class Home extends Component {
-  openTwitch() {
-    const twitchWeb = "https://twitch.tv/studiorenegade";
-    const twitchApp = "twitch://stream/studiorenegade";
-    Linking.canOpenURL(twitchApp).then(canOpen => {
-      if (canOpen) {
-        Linking.openURL(twitchApp);
-      } else {
-        Linking.openURL(twitchWeb);
-      }
-    });
-  }
-  render() {
-    return (
-      <View>
-        <Header />
-        <View style={styles.containerLive}>
-          <Text style={styles.live}>Actuellement en live !</Text>
-          <Text style={styles.emissionLive}>NELIGER!!!!!</Text>
-          <TouchableHighlight
-            style={styles.twitchLogo}
-            onPress={this.openTwitch}
-          >
-            <Image
-              source={require("../../res/images/twitch.png")}
-              style={{ height: 55, width: 55 }}
-            />
-          </TouchableHighlight>
-        </View>
-        <View>
-          <Text>Prochainement</Text>
-          <Agenda />
-        </View>
-      </View>
-    );
-  }
+    openTwitch() {
+        const twitchWeb = "https://twitch.tv/studiorenegade"
+        const twitchApp = "twitch://stream/studiorenegade"
+        Linking.canOpenURL(twitchApp).then((canOpen) => {
+            if (canOpen) {
+                Linking.openURL(twitchApp)
+            } else {
+                Linking.openURL(twitchWeb)
+            }
+        })
+    }
+    render() {
+        return (
+            <ScrollViewWithHeader style={{ flex: 1 }}>
+                <View style={styles.containerLive}>
+                    <Text style={styles.live}>Actuellement en live !</Text>
+                    <Text style={styles.emissionLive}>NELIGER!!!!!</Text>
+                    <TouchableHighlight style={styles.twitchLogo} onPress={this.openTwitch}>
+                        <Image source={require("../../res/images/twitch.png")} style={{ height: 55, width: 55 }} />
+                    </TouchableHighlight>
+                </View>
+                <View>
+                    <Text>Prochainement</Text>
+                    <Agenda />
+                </View>
+            </ScrollViewWithHeader>
+        )
+    }
 }
 
 const styles = StyleSheet.create({
-  containerLive: {
-    backgroundColor: "#000",
-    height: 60,
-    position: "relative"
-  },
-  live: {
-    fontSize: 18,
-    color: "#FFF",
-    fontFamily: "Montserrat-Light"
-  },
-  emissionLive: {
-    fontSize: 25,
-    color: "#FFF",
-    fontFamily: "Montserrat-Medium"
-  },
-  twitchLogo: {
-    position: "absolute",
-    left: "70%",
-    top: "5%"
-  }
-});
+    containerLive: {
+        backgroundColor: "#000",
+        height: 60,
+        position: "relative",
+    },
+    live: {
+        fontSize: 18,
+        color: "#FFF",
+        fontFamily: "Montserrat-Light",
+    },
+    emissionLive: {
+        fontSize: 25,
+        color: "#FFF",
+        fontFamily: "Montserrat-Medium",
+    },
+    twitchLogo: {
+        position: "absolute",
+        left: "70%",
+        top: "5%",
+    },
+})

--- a/src/screens/home/Home.js
+++ b/src/screens/home/Home.js
@@ -29,7 +29,7 @@ export default class Home extends Component {
                     <Text>Prochainement</Text>
                     <Agenda />
                 </View>
-            </View>
+            </ScrollViewWithHeader>
         )
     }
 }

--- a/src/screens/programs/Programs.js
+++ b/src/screens/programs/Programs.js
@@ -1,81 +1,69 @@
-import React, { Component } from "react";
-import {
-  StyleSheet,
-  Text,
-  View,
-  Image,
-  ScrollView,
-  Button
-} from "react-native";
-import { StackNavigator } from "react-navigation";
+import React, { Component } from "react"
+import { StyleSheet, Text, View, Image, ScrollView, Button } from "react-native"
 
 //Component
-import Header from "../../components/Header";
-import programs from "../../res/data/programs.json";
-import { Routes } from ".";
+import programs from "../../res/data/programs.json"
+import { Routes } from "."
+
+import ScrollViewWithHeader from "../../components/ScrollViewWithHeader"
 
 export default class Programs extends Component {
-  render() {
-    return (
-      <View style={{ justifyContent: "center", alignItems: "center" }}>
-        <ScrollView style={{ width: "100%" }}>
-          <View style={{ flex: 1 }}>
-            {programs.map(program => (
-              <View key={program.id} style={styles.container}>
-                <View key={program.id} style={styles.emission}>
-                  <Image
-                    style={styles.logoEmission}
-                    source={{ uri: program.logo }}
-                  />
-                  <View style={styles.containerDetail}>
-                    <Text style={styles.programName}>{program.name}</Text>
-                    <Button
-                      title="Description"
-                      onPress={() =>
-                        this.props.navigation.navigate(Routes.programsDetails, {
-                          programDetail: program
-                        })
-                      }
-                    />
-                  </View>
+    render() {
+        return (
+            <ScrollViewWithHeader style={{ flex: 1 }} navigation={this.props.navigation}>
+                <View style={{ flex: 1 }}>
+                    {programs.map((program) => (
+                        <View key={program.id} style={styles.container}>
+                            <View key={program.id} style={styles.emission}>
+                                <Image style={styles.logoEmission} source={{ uri: program.logo }} />
+                                <View style={styles.containerDetail}>
+                                    <Text style={styles.programName}>{program.name}</Text>
+                                    <Button
+                                        title="Description"
+                                        onPress={() =>
+                                            this.props.navigation.navigate(Routes.programsDetails, {
+                                                programDetail: program,
+                                            })
+                                        }
+                                    />
+                                </View>
+                            </View>
+                        </View>
+                    ))}
                 </View>
-              </View>
-            ))}
-          </View>
-        </ScrollView>
-      </View>
-    );
-  }
+            </ScrollViewWithHeader>
+        )
+    }
 }
 
 const styles = StyleSheet.create({
-  container: {
-    backgroundColor: "#DDD",
-    borderRadius: 80,
-    marginHorizontal: 20,
-    marginVertical: 10
-  },
-  emission: {
-    flex: 1,
-    flexDirection: "row",
-    height: 80
-  },
-  logoEmission: {
-    borderRadius: 40,
-    height: 80,
-    width: 80
-  },
-  containerDetail: {
-    flexDirection: "column",
-    justifyContent: "space-around",
-    flex: 1,
-    height: 60
-  },
-  programName: {
-    flex: 1,
-    textAlign: "center",
-    alignItems: "center",
-    padding: 20,
-    fontWeight: "500"
-  }
-});
+    container: {
+        backgroundColor: "#DDD",
+        borderRadius: 80,
+        marginHorizontal: 20,
+        marginVertical: 10,
+    },
+    emission: {
+        flex: 1,
+        flexDirection: "row",
+        height: 80,
+    },
+    logoEmission: {
+        borderRadius: 40,
+        height: 80,
+        width: 80,
+    },
+    containerDetail: {
+        flexDirection: "column",
+        justifyContent: "space-around",
+        flex: 1,
+        height: 60,
+    },
+    programName: {
+        flex: 1,
+        textAlign: "center",
+        alignItems: "center",
+        padding: 20,
+        fontWeight: "500",
+    },
+})

--- a/src/screens/programs/ProgramsDetails.js
+++ b/src/screens/programs/ProgramsDetails.js
@@ -1,47 +1,51 @@
-import React, { Component } from 'react';
-import { StyleSheet, Text, View, Image} from "react-native";
+import React, { Component } from "react"
+import { StyleSheet, Text, View, Image } from "react-native"
 
+import ScrollViewWithHeader from "../../components/ScrollViewWithHeader"
 
 export default class ProgramsDetails extends Component {
     static navigationOptions = {
-    title: "Détail Émission"
-  };
+        title: "Détail Émission",
+    }
 
-  render() {
-      const { params } = this.props.navigation.state;
-      const programDescription = params.programDetail.description;
-      const logoEmission = params.programDetail.logo;
-
-    return (
-      <View>
-        <View style={{ justifyContent: "center", alignItems: "center" }}>
-          <Image source={{ uri: logoEmission }} style={styles.logo} />
-        </View>
-        <Text style={styles.textContainer}>{programDescription}</Text>
-        <Text style={{ fontWeight: "900" }}>Streameurs</Text>
-        <View style={{ flexDirection: "row", justifyContent: "space-around", margin:10 }}>
-          <Image style={{ height: 150, width: 150, borderRadius: 75 }} source={{ uri: "https://picsum.photos/200/?random" }} />
-        </View>
-        <Text>Prochain stream : ???</Text>
-        <Text>Dernière émission : ??? </Text>
-      </View>
-    )};
+    render() {
+        const { params } = this.props.navigation.state
+        const programDescription = params.programDetail.description
+        const logoEmission = params.programDetail.logo
+        return (
+            <ScrollViewWithHeader style={{ flex: 1 }} navigation={this.props.navigation}>
+                <View style={{ justifyContent: "center", alignItems: "center" }}>
+                    <Image source={{ uri: logoEmission }} style={styles.logo} />
+                </View>
+                <Text style={styles.textContainer}>{programDescription}</Text>
+                <Text style={{ fontWeight: "900" }}>Streameurs</Text>
+                <View style={{ flexDirection: "row", justifyContent: "space-around", margin: 10 }}>
+                    <Image
+                        style={{ height: 150, width: 150, borderRadius: 75 }}
+                        source={{ uri: "https://picsum.photos/200/?random" }}
+                    />
+                </View>
+                <Text>Prochain stream : ???</Text>
+                <Text>Dernière émission : ??? </Text>
+            </ScrollViewWithHeader>
+        )
+    }
 }
 
 const styles = StyleSheet.create({
-  logo: {
-    marginTop: 10,
-    borderRadius: 40,
-    height: 80,
-    width: 80
-  },
-  textContainer: {
-    padding: 10,
-    textAlign: "justify"
-  },
-  streameur: {
-    height: 70,
-    width: 70,
-    borderRadius: 35
-  }
-});
+    logo: {
+        marginTop: 10,
+        borderRadius: 40,
+        height: 80,
+        width: 80,
+    },
+    textContainer: {
+        padding: 10,
+        textAlign: "justify",
+    },
+    streameur: {
+        height: 70,
+        width: 70,
+        borderRadius: 35,
+    },
+})

--- a/src/screens/programs/index.js
+++ b/src/screens/programs/index.js
@@ -17,8 +17,18 @@ export default createStackNavigator(
         [Routes.programsDetails]: ProgramsDetails,
     },
     {
-        navigationOptions: {
-            header: <Header />
-        }
+        navigationOptions: ({ navigation }) => {
+            const { params = {} } = navigation.state
+            const { headerHeight } = params
+            return {
+                header: (
+                    <Header
+                        navigation={navigation}
+                        hasBackButton={navigation.state.routeName !== Routes.programsHome}
+                        height={headerHeight}
+                    />
+                ),
+            }
+        },
     }
 )

--- a/src/screens/programs/index.js
+++ b/src/screens/programs/index.js
@@ -19,15 +19,9 @@ export default createStackNavigator(
     {
         navigationOptions: ({ navigation }) => {
             const { params = {} } = navigation.state
-            const { headerHeight } = params
+            const { scrollContentYOffset } = params
             return {
-                header: (
-                    <Header
-                        navigation={navigation}
-                        hasBackButton={navigation.state.routeName !== Routes.programsHome}
-                        height={headerHeight}
-                    />
-                ),
+                header: <Header navigation={navigation} scrollContentYOffset={scrollContentYOffset} />,
             }
         },
     }

--- a/src/screens/support-us/SupportUs.js
+++ b/src/screens/support-us/SupportUs.js
@@ -1,101 +1,70 @@
 import React, { Component } from "react"
-import {
-    SafeAreaView,
-    View,
-    Text,
-    StyleSheet,
-    Image,
-    Linking,
-    TouchableOpacity,
-    ScrollView,
-    Animated,
-} from "react-native"
+import { View, Text, StyleSheet, Image, Linking, TouchableOpacity } from "react-native"
 
-// Component
-import Header from "../../components/Header"
+import ScrollViewWithHeader from "../../components/ScrollViewWithHeader"
 
 export default class SupportUs extends Component {
-    state = {
-        scrollY: new Animated.Value(0),
-    }
-
-    _onScroll = Animated.event([{ nativeEvent: { contentOffset: { y: this.state.scrollY } } }])
-
     render() {
-        const headerHeight = Header.animatedHeight({ deltaY: this.state.scrollY })
         return (
-            <SafeAreaView style={{ flex: 1 }}>
-                <ScrollView style={{ flex: 1 }} scrollEventThrottle={16} onScroll={this._onScroll}>
-                    <Animated.View style={{ flex: 1, paddingTop: headerHeight }}>
-                        <View style={{ justifyContent: "center", alignItems: "center" }}>
-                            <Text style={{ fontFamily: "Montserrat-Medium", marginTop: 10, fontSize: 25 }}>
-                                MERCI À VOUS !
-                            </Text>
-                            <View style={{ width: "95%", marginTop: 10 }}>
-                                <Text style={styles.containerText}>
-                                    Aujourd'hui nous pouvons produire notre contenu grâce à vos financements ! Que vous
-                                    souhaitiez nous soutenir régulièrement sur Tipeee (à partir de 1€ par mois),
-                                    ponctuellement via des dons PayPal ou en profitant de votre abonnement Amazon
-                                    Premium via Twitch Prime, MERCI.
-                                </Text>
+            <ScrollViewWithHeader style={{ flex: 1 }}>
+                <View style={{ justifyContent: "center", alignItems: "center" }}>
+                    <Text style={{ fontFamily: "Montserrat-Medium", marginTop: 10, fontSize: 25 }}>MERCI À VOUS !</Text>
+                    <View style={{ width: "95%", marginTop: 10 }}>
+                        <Text style={styles.containerText}>
+                            Aujourd'hui nous pouvons produire notre contenu grâce à vos financements ! Que vous
+                            souhaitiez nous soutenir régulièrement sur Tipeee (à partir de 1€ par mois), ponctuellement
+                            via des dons PayPal ou en profitant de votre abonnement Amazon Premium via Twitch Prime,
+                            MERCI.
+                        </Text>
 
-                                <Text style={styles.containerText}>
-                                    Aujourd'hui nous poursuivons notre but : vous proposer toujours plus de contenu tout
-                                    en améliorant la qualité de ces derniers. Nous sommes nous mêmes donateurs de
-                                    l'association de loi 1901. Merci encore à vous !
-                                </Text>
-                                <View style={{ flexDirection: "row", justifyContent: "flex-end" }}>
-                                    <Image
-                                        source={require("../../res/images/signature.png")}
-                                        style={{ width: 250, height: 100 }}
-                                    />
-                                </View>
-                            </View>
+                        <Text style={styles.containerText}>
+                            Aujourd'hui nous poursuivons notre but : vous proposer toujours plus de contenu tout en
+                            améliorant la qualité de ces derniers. Nous sommes nous mêmes donateurs de l'association de
+                            loi 1901. Merci encore à vous !
+                        </Text>
+                        <View style={{ flexDirection: "row", justifyContent: "flex-end" }}>
+                            <Image
+                                source={require("../../res/images/signature.png")}
+                                style={{ width: 250, height: 100 }}
+                            />
                         </View>
+                    </View>
+                </View>
 
-                        <View
-                            style={{
-                                flexDirection: "column",
-                                justifyContent: "space-around",
-                                alignItems: "center",
-                                marginTop: 70,
-                            }}
-                        >
-                            <TouchableOpacity
-                                onPress={() => Linking.openURL("https://www.twitch.tv/subs/studiorenegade")}
-                                style={{ flexDirection: "row", justifyContent: "space-around", alignItems: "center" }}
-                            >
-                                <Image
-                                    source={require("../../res/images/twitch.png")}
-                                    style={{ height: 70, width: 70 }}
-                                />
-                                <Text style={styles.containerText}>S'abonner</Text>
-                            </TouchableOpacity>
+                <View
+                    style={{
+                        flexDirection: "column",
+                        justifyContent: "space-around",
+                        alignItems: "center",
+                        marginTop: 70,
+                    }}
+                >
+                    <TouchableOpacity
+                        onPress={() => Linking.openURL("https://www.twitch.tv/subs/studiorenegade")}
+                        style={{ flexDirection: "row", justifyContent: "space-around", alignItems: "center" }}
+                    >
+                        <Image source={require("../../res/images/twitch.png")} style={{ height: 70, width: 70 }} />
+                        <Text style={styles.containerText}>S'abonner</Text>
+                    </TouchableOpacity>
 
-                            <TouchableOpacity onPress={() => Linking.openURL("https://www.tipeee.com/stdrenegade")}>
-                                <Image
-                                    source={require("../../res/images/Tipeee_logo.png")}
-                                    style={{ height: 50, width: 135 }}
-                                />
-                            </TouchableOpacity>
+                    <TouchableOpacity onPress={() => Linking.openURL("https://www.tipeee.com/stdrenegade")}>
+                        <Image
+                            source={require("../../res/images/Tipeee_logo.png")}
+                            style={{ height: 50, width: 135 }}
+                        />
+                    </TouchableOpacity>
 
-                            <TouchableOpacity
-                                onPress={() =>
-                                    Linking.openURL(
-                                        "https://www.paypal.com/cgi-bin/webscr/?cmd=_s-xclick&hosted_button_id=QZXLDBZV3UEWS"
-                                    )
-                                }
-                            >
-                                <Image
-                                    source={require("../../res/images/paypal.png")}
-                                    style={{ height: 50, width: 120 }}
-                                />
-                            </TouchableOpacity>
-                        </View>
-                    </Animated.View>
-                </ScrollView>
-                <Header style={styles.header} height={headerHeight} />
-            </SafeAreaView>
+                    <TouchableOpacity
+                        onPress={() =>
+                            Linking.openURL(
+                                "https://www.paypal.com/cgi-bin/webscr/?cmd=_s-xclick&hosted_button_id=QZXLDBZV3UEWS"
+                            )
+                        }
+                    >
+                        <Image source={require("../../res/images/paypal.png")} style={{ height: 50, width: 120 }} />
+                    </TouchableOpacity>
+                </View>
+            </ScrollViewWithHeader>
         )
     }
 }
@@ -107,12 +76,6 @@ const styles = StyleSheet.create({
         fontSize: 15,
         fontWeight: "400",
         lineHeight: 20,
-    },
-    header: {
-        position: "absolute",
-        top: 0,
-        left: 0,
-        right: 0,
     },
     bar: {
         marginTop: 28,

--- a/src/screens/support-us/SupportUs.js
+++ b/src/screens/support-us/SupportUs.js
@@ -1,36 +1,32 @@
 import React, { Component } from "react"
-import { View, Text, StyleSheet, Image, Linking, TouchableOpacity, ScrollView, Animated } from "react-native"
+import {
+    SafeAreaView,
+    View,
+    Text,
+    StyleSheet,
+    Image,
+    Linking,
+    TouchableOpacity,
+    ScrollView,
+    Animated,
+} from "react-native"
 
 // Component
 import Header from "../../components/Header"
 
-const HEADER_MAX_HEIGHT = 125
-const HEADER_MIN_HEIGHT = 50
-const HEADER_SCROLL_DISTANCE = HEADER_MAX_HEIGHT - HEADER_MIN_HEIGHT
-
 export default class SupportUs extends Component {
-    constructor(props) {
-        super(props)
-
-        this.state = {
-            scrollY: new Animated.Value(0),
-        }
+    state = {
+        scrollY: new Animated.Value(0),
     }
+
+    _onScroll = Animated.event([{ nativeEvent: { contentOffset: { y: this.state.scrollY } } }])
+
     render() {
-        const headerHeight = this.state.scrollY.interpolate({
-            inputRange: [0, HEADER_SCROLL_DISTANCE],
-            outputRange: [HEADER_MAX_HEIGHT, HEADER_MIN_HEIGHT],
-            extrapolate: "clamp",
-        })
+        const headerHeight = Header.animatedHeight({ deltaY: this.state.scrollY })
         return (
-            <View style={{ flex: 1 }}>
-                <ScrollView
-                    style={{ flex: 1 }}
-                    contentContainerStyle={styles.scrollViewContent}
-                    scrollEventThrottle={16}
-                    onScroll={Animated.event([{ nativeEvent: { contentOffset: { y: this.state.scrollY } } }])}
-                >
-                    <View style={{ flex: 1 }}>
+            <SafeAreaView style={{ flex: 1 }}>
+                <ScrollView style={{ flex: 1 }} scrollEventThrottle={16} onScroll={this._onScroll}>
+                    <Animated.View style={{ flex: 1, paddingTop: headerHeight }}>
                         <View style={{ justifyContent: "center", alignItems: "center" }}>
                             <Text style={{ fontFamily: "Montserrat-Medium", marginTop: 10, fontSize: 25 }}>
                                 MERCI À VOUS !
@@ -96,12 +92,10 @@ export default class SupportUs extends Component {
                                 />
                             </TouchableOpacity>
                         </View>
-                    </View>
+                    </Animated.View>
                 </ScrollView>
-                <Animated.View style={[styles.header, { height: headerHeight }]}>
-                    <Header />
-                </Animated.View>
-            </View>
+                <Header style={styles.header} height={headerHeight} />
+            </SafeAreaView>
         )
     }
 }
@@ -119,8 +113,6 @@ const styles = StyleSheet.create({
         top: 0,
         left: 0,
         right: 0,
-        backgroundColor: "#4A0B0F",
-        overflow: "hidden",
     },
     bar: {
         marginTop: 28,
@@ -132,9 +124,5 @@ const styles = StyleSheet.create({
         backgroundColor: "transparent",
         color: "white",
         fontSize: 18,
-    },
-    scrollViewContent: {
-        marginTop: HEADER_MAX_HEIGHT,
-        paddingBottom: HEADER_MAX_HEIGHT,
     },
 })


### PR DESCRIPTION
Integrate Header animation without the use of magic numbers. Animation has also been improved to bounce and fade.

In order to avoid use of magic number to handle SafeArea insets I have also proposed an update of react-native to get these values via a callback ([react-native#19627](https://github.com/facebook/react-native/pull/19627)).

~~Some works remains for integration in stack navigator, especially for the transition between screens.~~