### PR TITLE
Use a shorter version of mapDispatchToProps

### DIFF
--- a/src/components/Agenda.js
+++ b/src/components/Agenda.js
@@ -197,16 +197,7 @@ const mapStateToProps = ({ renegade }) => ({
     renegade,
 })
 
-const mapDispatchToProps = (dispatch) => ({
-    storeRenegadeData: (data) => {
-        dispatch(storeRenegadeData(data))
-    },
-    fetchRenegadeData: () => {
-        dispatch(fetchRenegadeData())
-    },
-})
-
 export default connect(
     mapStateToProps,
-    mapDispatchToProps
+    { storeRenegadeData, fetchRenegadeData }
 )(Agenda)


### PR DESCRIPTION
`connect` also accept object for `mapDispatchToProps`, this is shorter and better for code readability 
(IMO).

See react-redux `connect` API [documentation](https://github.com/reduxjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options) for `mapDispatchToProps`