### PR TITLE
Generic way to hide/show header back button

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -19,9 +19,11 @@ class Header extends React.Component {
     static propTypes = {
         style: ViewPropTypes.style,
         scrollContentYOffset: PropTypes.number,
+        shouldShowBackButton: PropTypes.bool,
     }
     static defaultProps = {
         scrollContentYOffset: 0,
+        shouldShowBackButton: false,
     }
     // Header animation configuration
     static minHeight = 0
@@ -78,17 +80,14 @@ class Header extends React.Component {
                         resizeMode="contain"
                     />
                 </SafeAreaView>
-                {this.props.navigation &&
-                    this.props.navigation.state &&
-                    this.props.navigation.state.routeName &&
-                    this.props.navigation.state.routeName === Routes.programsDetails && (
-                        <TouchableOpacity
-                            onPress={() => (this.props.navigation ? this.props.navigation.goBack() : undefined)}
-                            style={{ padding: 10, position: "absolute", top: 30, left: 20 }}
-                        >
-                            <IconMCI name="arrow-left" size={36} color="#FFF" />
-                        </TouchableOpacity>
-                    )}
+                {this.props.shouldShowBackButton && (
+                    <TouchableOpacity
+                        onPress={() => (this.props.navigation ? this.props.navigation.goBack() : undefined)}
+                        style={{ padding: 10, position: "absolute", top: 30, left: 20 }}
+                    >
+                        <IconMCI name="arrow-left" size={36} color="#FFF" />
+                    </TouchableOpacity>
+                )}
             </ImageBackground>
         )
     }

--- a/src/screens/programs/index.js
+++ b/src/screens/programs/index.js
@@ -21,7 +21,13 @@ export default createStackNavigator(
             const { params = {} } = navigation.state
             const { scrollContentYOffset } = params
             return {
-                header: <Header navigation={navigation} scrollContentYOffset={scrollContentYOffset} />,
+                header: ({ index }) => (
+                    <Header
+                        navigation={navigation}
+                        scrollContentYOffset={scrollContentYOffset}
+                        shouldShowBackButton={index !== 0}
+                    />
+                ),
             }
         },
     }


### PR DESCRIPTION
Because header component is generic and could be reused in other places in the application, it should not be aware of our application routes.

By taking a look at `react-navigation` sources we can see that `header` property in `createStackNavigator` accept values of type:
- `React.ReactElement<any>`
- `(headerProps: HeaderProps) => React.ReactElement<any>)`
- `null`

And searching a bit further we could see that `HeaderProps` has an `index` property containing its position in the `StackNavigator`. By testing this value we are able to know if we should show the back button (`index !== 0`) or not.